### PR TITLE
Deactivate Clean up Github Env

### DIFF
--- a/.github/workflows/fly.io-deploy-pull-request.yml
+++ b/.github/workflows/fly.io-deploy-pull-request.yml
@@ -43,10 +43,12 @@ jobs:
           postgres: paper-trader-db
           # Whether new commits to the PR should re-deploy the Fly app
           update: # optional, default is true
-      - name: Clean up GitHub environment
-        uses: strumwolf/delete-deployment-environment@v2
-        if: ${{ github.event.action == 'closed' }}
-        with:
-          # ⚠️ The provided token needs permission for admin write:org
-          token: ${{ secrets.PAPER_TRADER_STAGING_TOKEN }}
-          environment: pr-${{ github.event.number }}
+      # Currently, there is an error related to below action, where it can't find
+      # the deployments in the environment
+      # - name: Clean up GitHub environment
+      #   uses: strumwolf/delete-deployment-environment@v2
+      #   if: ${{ github.event.action == 'closed' }}
+      #   with:
+      #     # ⚠️ The provided token needs permission for admin write:org
+      #     token: ${{ secrets.PAPER_TRADER_STAGING_TOKEN }}
+      #     environment: pr-${{ github.event.number }}


### PR DESCRIPTION
There's an error related to the action that tries to delete the Github environments, where it returns an error that the environment isn't found despite detecting the deployments inside of it. Interestingly, having it run to delete a non-existent environment has no errors.

For now to stop the checks from failing, commented the action out to revisit in the future. As such, will need to manually delete the Github environments created from the remaining steps in the action. 