### PR TITLE
Add configuration arguments for fly to deploy in production

### DIFF
--- a/server/fly.toml
+++ b/server/fly.toml
@@ -8,9 +8,13 @@ processes = []
 [build]
   builder = "heroku/buildpacks:20"
 
+  [build.args]
+    NODE_ENV="production"
+
 [env]
   PORT = "8080"
-
+  NODE_ENV = "production"
+  
 [experimental]
   allowed_public_ports = []
   auto_rollback = true


### PR DESCRIPTION
The previous fly.toml file did not change the NODE_ENV to production by default. 

1. To force this change, NODE_ENV="production" is set at an environment variable. 
2. In addition, the heroku build packs didn't recognize it's in production during the build process, so it needs to be set as a build argument. 
3. Note, both changes are needed