### PR TITLE
Add login spinner while waiting to redirect to profile page

### DIFF
--- a/app/src/pages/Login/index.tsx
+++ b/app/src/pages/Login/index.tsx
@@ -9,7 +9,7 @@ import { DISCORD_REDIRECT_URI } from "../../config";
 
 /**
  * Props:
- * - None
+ * - handleLogin: function to be called in App
  * 
  * State:
  * - searchParams: null or string

--- a/app/src/pages/Login/index.tsx
+++ b/app/src/pages/Login/index.tsx
@@ -1,7 +1,7 @@
 
 import { useEffect, useContext } from 'react';
 import { Navigate, useSearchParams } from 'react-router-dom'
-import { Button, Pane, EditIcon, Heading } from "evergreen-ui";
+import { Button, Pane, EditIcon, Heading, Spinner } from "evergreen-ui";
 import UserContext from "../../UserContext";
 
 import UserSession from '../../helpers/UserSession';
@@ -27,11 +27,11 @@ function Login({ handleLogin }: any) {
 
   console.debug("Login", { user });
 
-  const authCode = searchParams.get('code')
+  const authCode = searchParams.get('code') ?? undefined;
 
   /** Checks if this component is mounted after a Discord OAuth redirect */
   useEffect(function loadUser() {
-    if (authCode !== null) {
+    if (authCode !== undefined) {
       handleLogin();
     }
   }, [handleLogin, authCode]);
@@ -53,22 +53,30 @@ function Login({ handleLogin }: any) {
 
   return (
     <Pane display="flex" flexDirection="column" alignItems="center">
-      <Pane display="flex" flexDirection="column" alignItems="center">
-        <Heading is="h1" size={900}>
-          Login
-        </Heading>
-        <Pane>
-          <Button
-            marginY={8}
-            marginRight={12}
-            iconBefore={EditIcon}
-            size="large"
-            onClick={getDiscordOAuthCode}
-          >
-            Login With Discord
-          </Button>
-        </Pane>
-      </Pane>
+      {authCode &&
+        <Pane display="flex" flexDirection="column" alignItems="center">
+          <Heading is="h1" size={900}>
+            Logging In...
+          </Heading>
+          <Spinner marginX="auto" marginY={50} />
+        </Pane>}
+      {!authCode &&
+        <Pane display="flex" flexDirection="column" alignItems="center">
+          <Heading is="h1" size={900}>
+            Login
+          </Heading>
+          <Pane>
+            <Button
+              marginY={8}
+              marginX="auto"
+              iconBefore={EditIcon}
+              size="large"
+              onClick={getDiscordOAuthCode}
+            >
+              Login With Discord
+            </Button>
+          </Pane>
+        </Pane>}
     </Pane>
   )
 }


### PR DESCRIPTION
When a user is redirected from Discord, there can be a delay until the App User context is updated which may cause them to try to login again. By having a spinner component render instead of the login button, this prevents the user from trying to login again.